### PR TITLE
Try to use native prepared statement

### DIFF
--- a/src/PdoWrapper.php
+++ b/src/PdoWrapper.php
@@ -198,7 +198,7 @@ class PdoWrapper extends \PDO
             // If you want to Show Class exceptions on Screen, Uncomment below code 
             $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             // Use this setting to force PDO to either always emulate prepared statements (if TRUE), or to try to use native prepared statements (if FALSE). 
-            $this->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+            $this->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
             // set default pdo fetch mode as fetch assoc
             $this->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
         } catch (PDOException $e) {


### PR DESCRIPTION
# Changed log

It should set ```false``` and it always try to use the native prepared statement.

If the native mode doesn't support, ```PDO``` class will change into the emulated mode.

It's related to issue #1 .